### PR TITLE
feat: implement Streamable HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ A Model Context Protocol (MCP) server implementation that interfaces with the [H
 
 Pick the workflow that fits your setup:
 
-| Scenario              | Command                                     | Requirements               |
-| :-------------------- | :------------------------------------------ | :------------------------- |
-| **One-off stdio run** | `HEVY_API_KEY=sk_live... npx -y hevy-mcp`   | Node.js ≥ 24, Hevy API key |
-| **Local development** | `npm install && npm run build && npm start` | `.env` with `HEVY_API_KEY` |
+| Scenario              | Command                                                                | Requirements               |
+| :-------------------- | :--------------------------------------------------------------------- | :------------------------- |
+| **One-off stdio run** | `HEVY_API_KEY=sk_live... npx -y hevy-mcp`                              | Node.js ≥ 24, Hevy API key |
+| **HTTP mode**         | `HEVY_API_KEY=sk_live... npx -y hevy-mcp --transport=http --port=3000` | Node.js ≥ 24, Hevy API key |
+| **Local development** | `npm install && npm run build && npm start`                            | `.env` with `HEVY_API_KEY` |
 
 ---
 
@@ -150,12 +151,34 @@ HEVY_API_KEY=your_hevy_api_key_here
 
 ---
 
+## Transport Modes
+
+`hevy-mcp` supports two transport modes:
+
+### stdio (default)
+
+The default mode. Used by all MCP clients that launch the server as a subprocess:
+
+```bash
+HEVY_API_KEY=your_key npx -y hevy-mcp
+```
+
+### Streamable HTTP
+
+Use `--transport=http` to start a Streamable HTTP server. The server listens on `/mcp` and manages one MCP session per client connection.
+
+```bash
+HEVY_API_KEY=your_key npx -y hevy-mcp --transport=http --port=3000
+```
+
+Default port is `3000`. Inspect with:
+
+```bash
+npx @modelcontextprotocol/inspector http://localhost:3000/mcp
+```
+
 <details>
-<summary><strong>⚠️ Deprecation Notices (HTTP/SSE & Docker)</strong></summary>
-
-### Stdio Only
-
-As of version **1.18.0**, `hevy-mcp` only supports **stdio** transport. HTTP/SSE transport has been completely removed to simplify the codebase and focus on the native MCP experience.
+<summary><strong>⚠️ Deprecation Notice (Docker)</strong></summary>
 
 ### Docker
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { registerTemplateTools } from "./tools/templates.js";
 import { registerWebhookTools } from "./tools/webhooks.js";
 import { registerWorkoutTools } from "./tools/workouts.js";
 import { assertApiKey, parseConfig } from "./utils/config.js";
+import { startHttpServer } from "./utils/httpServer.js";
 import { createClient } from "./utils/hevyClient.js";
 
 const HEVY_API_BASEURL = "https://api.hevyapp.com";
@@ -89,11 +90,16 @@ export default function createServer({ config }: { config: ServerConfig }) {
 export async function runServer() {
 	const args = process.argv.slice(2);
 	const cfg = parseConfig(args, process.env);
-	const apiKey = cfg.apiKey;
-	assertApiKey(apiKey);
+	assertApiKey(cfg.apiKey);
 
-	const server = buildServer(apiKey);
-	console.error("Starting MCP server in stdio mode");
-	const transport = new StdioServerTransport();
-	await server.connect(transport);
+	if (cfg.transport === "http") {
+		const port = cfg.port ?? 3000;
+		console.error(`Starting MCP server in HTTP mode on port ${port}`);
+		await startHttpServer(() => buildServer(cfg.apiKey!), port);
+	} else {
+		console.error("Starting MCP server in stdio mode");
+		const server = buildServer(cfg.apiKey!);
+		const transport = new StdioServerTransport();
+		await server.connect(transport);
+	}
 }

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -56,4 +56,10 @@ describe("parseConfig", () => {
 		const cfg = parseConfig([], env({}));
 		expect(cfg.port).toBeUndefined();
 	});
+
+	it("throws on out-of-range port", () => {
+		expect(() => parseConfig(["--port=99999"], env({}))).toThrow(
+			/Invalid --port value/,
+		);
+	});
 });

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -31,4 +31,29 @@ describe("parseConfig", () => {
 		const cfg = parseConfig([], env({ HEVY_API_KEY: "envOnly" }));
 		expect(cfg.apiKey).toBe("envOnly");
 	});
+
+	it("parses --transport=http", () => {
+		const cfg = parseConfig(["--transport=http"], env({}));
+		expect(cfg.transport).toBe("http");
+	});
+
+	it("parses --transport=stdio", () => {
+		const cfg = parseConfig(["--transport=stdio"], env({}));
+		expect(cfg.transport).toBe("stdio");
+	});
+
+	it("transport defaults to undefined when not provided", () => {
+		const cfg = parseConfig([], env({}));
+		expect(cfg.transport).toBeUndefined();
+	});
+
+	it("parses --port=4000", () => {
+		const cfg = parseConfig(["--port=4000"], env({}));
+		expect(cfg.port).toBe(4000);
+	});
+
+	it("port defaults to undefined when not provided", () => {
+		const cfg = parseConfig([], env({}));
+		expect(cfg.port).toBeUndefined();
+	});
 });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,5 +1,7 @@
 export interface HevyConfig {
 	apiKey?: string;
+	transport?: "stdio" | "http";
+	port?: number;
 }
 
 /**
@@ -15,6 +17,9 @@ export function parseConfig(
 	env: NodeJS.ProcessEnv,
 ): HevyConfig {
 	let apiKey = "";
+	let transport: "stdio" | "http" | undefined;
+	let port: number | undefined;
+
 	const apiKeyArgPatterns = [
 		/^--hevy-api-key=(.+)$/i,
 		/^--hevyApiKey=(.+)$/i,
@@ -28,7 +33,14 @@ export function parseConfig(
 				break;
 			}
 		}
-		if (apiKey) break;
+		const transportMatch = raw.match(/^--transport=(stdio|http)$/i);
+		if (transportMatch) {
+			transport = transportMatch[1].toLowerCase() as "stdio" | "http";
+		}
+		const portMatch = raw.match(/^--port=(\d+)$/);
+		if (portMatch) {
+			port = parseInt(portMatch[1], 10);
+		}
 	}
 	if (!apiKey) {
 		apiKey = env.HEVY_API_KEY || "";
@@ -36,6 +48,8 @@ export function parseConfig(
 
 	return {
 		apiKey,
+		transport,
+		port,
 	};
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -39,7 +39,13 @@ export function parseConfig(
 		}
 		const portMatch = raw.match(/^--port=(\d+)$/);
 		if (portMatch) {
-			port = parseInt(portMatch[1], 10);
+			const parsedPort = parseInt(portMatch[1], 10);
+			if (parsedPort < 0 || parsedPort > 65535) {
+				throw new Error(
+					`Invalid --port value "${portMatch[1]}". Expected an integer between 0 and 65535.`,
+				);
+			}
+			port = parsedPort;
 		}
 	}
 	if (!apiKey) {

--- a/src/utils/httpServer.test.ts
+++ b/src/utils/httpServer.test.ts
@@ -1,12 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { createHttpServer } from "./httpServer.js";
+import { startHttpServer } from "./httpServer.js";
 
-describe("createHttpServer", () => {
-	it("throws because HTTP transport is removed", () => {
-		const call = () => createHttpServer();
-
-		expect(call).toThrowError(/HTTP\/SSE transport has been removed/);
-		expect(call).toThrowError(/use stdio instead of HTTP\/SSE/);
-		expect(call).toThrowError(/migration-from-httpsse-transport/);
+describe("startHttpServer", () => {
+	it("is a function", () => {
+		expect(typeof startHttpServer).toBe("function");
 	});
 });

--- a/src/utils/httpServer.test.ts
+++ b/src/utils/httpServer.test.ts
@@ -1,8 +1,57 @@
-import { describe, expect, it } from "vitest";
+import type { Server } from "node:http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { startHttpServer } from "./httpServer.js";
 
+function buildMinimalServer() {
+	return new McpServer({ name: "test", version: "0.0.0" });
+}
+
+async function closeServer(server: Server): Promise<void> {
+	return new Promise((resolve, reject) =>
+		server.close((err) => (err ? reject(err) : resolve())),
+	);
+}
+
 describe("startHttpServer", () => {
-	it("is a function", () => {
-		expect(typeof startHttpServer).toBe("function");
+	let server: Server;
+	let base: string;
+
+	beforeEach(async () => {
+		server = await startHttpServer(buildMinimalServer, 0);
+		const addr = server.address();
+		if (!addr || typeof addr === "string") throw new Error("No address");
+		base = `http://localhost:${addr.port}`;
+	});
+
+	afterEach(() => closeServer(server));
+
+	it("non-/mcp URL returns 404", async () => {
+		const res = await fetch(`${base}/other`);
+		expect(res.status).toBe(404);
+	});
+
+	it("/mcp with unknown session ID returns 404 JSON", async () => {
+		const res = await fetch(`${base}/mcp`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"mcp-session-id": "unknown-session",
+			},
+			body: JSON.stringify({ jsonrpc: "2.0", method: "ping", id: 1 }),
+		});
+		expect(res.status).toBe(404);
+		expect(res.headers.get("content-type")).toContain("application/json");
+		const data = (await res.json()) as { error: { code: number } };
+		expect(data.error.code).toBe(-32000);
+	});
+
+	it("oversized body returns 413", async () => {
+		const res = await fetch(`${base}/mcp`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: "x".repeat(1024 * 1024 + 1),
+		});
+		expect(res.status).toBe(413);
 	});
 });

--- a/src/utils/httpServer.ts
+++ b/src/utils/httpServer.ts
@@ -1,15 +1,79 @@
-/**
- * Legacy placeholder exported to provide a clear error for downstream consumers.
- * HTTP transport support has been removed from hevy-mcp and only stdio mode is supported.
- */
-export function createHttpServer(): never {
-	throw new Error(`HTTP/SSE transport has been removed from hevy-mcp (since v1.18.0).
-The server now only supports stdio transport.
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-To fix this:
-1. Update to the latest version: npx -y hevy-mcp@latest
-2. Update your client configuration to use stdio instead of HTTP/SSE
-3. Follow the migration guide (includes client examples):
-   https://github.com/chrisdoc/hevy-mcp#migration-from-httpsse-transport
-`);
+type Session = {
+	transport: StreamableHTTPServerTransport;
+	server: McpServer;
+};
+
+async function readBody(req: IncomingMessage): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		req.on("data", (chunk: Buffer) => chunks.push(chunk));
+		req.on("end", () => {
+			const raw = Buffer.concat(chunks).toString("utf8");
+			try {
+				resolve(raw ? JSON.parse(raw) : undefined);
+			} catch {
+				resolve(undefined);
+			}
+		});
+		req.on("error", reject);
+	});
+}
+
+export function startHttpServer(
+	buildServer: () => McpServer,
+	port: number,
+): Promise<Server> {
+	const sessions = new Map<string, Session>();
+
+	const httpServer = createServer(async (req, res) => {
+		if (req.url !== "/mcp") {
+			res.writeHead(404).end();
+			return;
+		}
+
+		let body: unknown;
+		if (req.method === "POST") body = await readBody(req);
+
+		const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+		if (sessionId && sessions.has(sessionId)) {
+			await sessions.get(sessionId)!.transport.handleRequest(req, res, body);
+			return;
+		}
+
+		if (!sessionId && req.method === "POST" && isInitializeRequest(body)) {
+			const transport = new StreamableHTTPServerTransport({
+				sessionIdGenerator: () => randomUUID(),
+				onsessioninitialized: (id) => {
+					sessions.set(id, { transport, server: mcpServer });
+				},
+			});
+			transport.onclose = () => {
+				if (transport.sessionId) sessions.delete(transport.sessionId);
+			};
+			const mcpServer = buildServer();
+			await mcpServer.connect(transport);
+			await transport.handleRequest(req, res, body);
+			return;
+		}
+
+		res.writeHead(404).end(
+			JSON.stringify({
+				jsonrpc: "2.0",
+				error: { code: -32000, message: "Session not found" },
+				id: null,
+			}),
+		);
+	});
+
+	return new Promise((resolve, reject) => {
+		httpServer.listen(port, () => resolve(httpServer));
+		httpServer.on("error", reject);
+	});
 }

--- a/src/utils/httpServer.ts
+++ b/src/utils/httpServer.ts
@@ -1,24 +1,65 @@
 import { randomUUID } from "node:crypto";
-import { createServer, type IncomingMessage, type Server } from "node:http";
+import {
+	createServer,
+	type IncomingMessage,
+	type Server,
+	type ServerResponse,
+} from "node:http";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const MAX_BODY_BYTES = 1024 * 1024; // 1 MiB
 
 type Session = {
 	transport: StreamableHTTPServerTransport;
 	server: McpServer;
 };
 
+function sendJsonError(
+	res: ServerResponse,
+	status: number,
+	code: number,
+	message: string,
+): void {
+	const body = JSON.stringify({
+		jsonrpc: "2.0",
+		error: { code, message },
+		id: null,
+	});
+	res
+		.writeHead(status, {
+			"Content-Type": "application/json",
+			"Content-Length": Buffer.byteLength(body).toString(),
+		})
+		.end(body);
+}
+
 async function readBody(req: IncomingMessage): Promise<unknown> {
 	return new Promise((resolve, reject) => {
 		const chunks: Buffer[] = [];
-		req.on("data", (chunk: Buffer) => chunks.push(chunk));
+		let totalBytes = 0;
+		let tooLarge = false;
+
+		req.on("data", (chunk: Buffer) => {
+			totalBytes += chunk.byteLength;
+			if (totalBytes > MAX_BODY_BYTES) {
+				tooLarge = true;
+				// Keep draining so the socket stays intact for the 413 response
+				return;
+			}
+			chunks.push(chunk);
+		});
 		req.on("end", () => {
+			if (tooLarge) {
+				reject(new Error("Request body too large"));
+				return;
+			}
 			const raw = Buffer.concat(chunks).toString("utf8");
 			try {
 				resolve(raw ? JSON.parse(raw) : undefined);
 			} catch {
-				resolve(undefined);
+				reject(new Error("Invalid JSON body"));
 			}
 		});
 		req.on("error", reject);
@@ -32,44 +73,57 @@ export function startHttpServer(
 	const sessions = new Map<string, Session>();
 
 	const httpServer = createServer(async (req, res) => {
-		if (req.url !== "/mcp") {
-			res.writeHead(404).end();
-			return;
+		try {
+			if (req.url !== "/mcp") {
+				res.writeHead(404).end();
+				return;
+			}
+
+			let body: unknown;
+			if (req.method === "POST") {
+				try {
+					body = await readBody(req);
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : "Bad request";
+					const status = msg === "Request body too large" ? 413 : 400;
+					sendJsonError(res, status, -32700, msg);
+					return;
+				}
+			}
+
+			const sessionIdHeader = req.headers["mcp-session-id"];
+			const sessionId = Array.isArray(sessionIdHeader)
+				? sessionIdHeader[0]
+				: sessionIdHeader;
+
+			if (sessionId && sessions.has(sessionId)) {
+				await sessions.get(sessionId)!.transport.handleRequest(req, res, body);
+				return;
+			}
+
+			if (!sessionId && req.method === "POST" && isInitializeRequest(body)) {
+				let mcpServer: McpServer;
+				const transport = new StreamableHTTPServerTransport({
+					sessionIdGenerator: () => randomUUID(),
+					onsessioninitialized: (id) => {
+						sessions.set(id, { transport, server: mcpServer });
+					},
+				});
+				transport.onclose = () => {
+					if (transport.sessionId) sessions.delete(transport.sessionId);
+				};
+				mcpServer = buildServer();
+				await mcpServer.connect(transport);
+				await transport.handleRequest(req, res, body);
+				return;
+			}
+
+			sendJsonError(res, 404, -32000, "Session not found");
+		} catch {
+			if (!res.headersSent) {
+				sendJsonError(res, 500, -32603, "Internal error");
+			}
 		}
-
-		let body: unknown;
-		if (req.method === "POST") body = await readBody(req);
-
-		const sessionId = req.headers["mcp-session-id"] as string | undefined;
-
-		if (sessionId && sessions.has(sessionId)) {
-			await sessions.get(sessionId)!.transport.handleRequest(req, res, body);
-			return;
-		}
-
-		if (!sessionId && req.method === "POST" && isInitializeRequest(body)) {
-			const transport = new StreamableHTTPServerTransport({
-				sessionIdGenerator: () => randomUUID(),
-				onsessioninitialized: (id) => {
-					sessions.set(id, { transport, server: mcpServer });
-				},
-			});
-			transport.onclose = () => {
-				if (transport.sessionId) sessions.delete(transport.sessionId);
-			};
-			const mcpServer = buildServer();
-			await mcpServer.connect(transport);
-			await transport.handleRequest(req, res, body);
-			return;
-		}
-
-		res.writeHead(404).end(
-			JSON.stringify({
-				jsonrpc: "2.0",
-				error: { code: -32000, message: "Session not found" },
-				id: null,
-			}),
-		);
 	});
 
 	return new Promise((resolve, reject) => {

--- a/tests/integration/http-transport.integration.test.ts
+++ b/tests/integration/http-transport.integration.test.ts
@@ -1,12 +1,49 @@
-import { describe, expect, it } from "vitest";
-import { createHttpServer } from "../../src/utils/httpServer.js";
+import type { Server } from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { startHttpServer } from "../../src/utils/httpServer.js";
+
+function buildMinimalServer() {
+	const server = new McpServer({ name: "test-server", version: "0.0.0" });
+	server.registerTool(
+		"noop",
+		{ description: "A no-op tool for testing" },
+		async () => ({ content: [] }),
+	);
+	return server;
+}
 
 describe("HTTP transport integration", () => {
-	it("is no longer supported", () => {
-		const call = () => createHttpServer();
+	let httpServer: Server;
+	let port: number;
 
-		expect(call).toThrow(/HTTP\/SSE transport has been removed/);
-		expect(call).toThrow(/use stdio instead of HTTP\/SSE/);
-		expect(call).toThrow(/migration-from-httpsse-transport/);
+	beforeEach(async () => {
+		httpServer = await startHttpServer(buildMinimalServer, 0);
+		const addr = httpServer.address();
+		if (!addr || typeof addr === "string") throw new Error("No address");
+		port = addr.port;
+	});
+
+	afterEach(
+		() =>
+			new Promise<void>((resolve, reject) => {
+				httpServer.close((err) => (err ? reject(err) : resolve()));
+			}),
+	);
+
+	it("client can connect and list tools", async () => {
+		const url = new URL(`http://localhost:${port}/mcp`);
+		const transport = new StreamableHTTPClientTransport(url);
+		const client = new Client({ name: "test-client", version: "0.0.0" });
+		await client.connect(transport);
+
+		const result = await client.listTools();
+		expect(result).toHaveProperty("tools");
+		expect(Array.isArray(result.tools)).toBe(true);
+		expect(result.tools.find((t) => t.name === "noop")).toBeDefined();
+
+		await client.close();
 	});
 });

--- a/tests/integration/http-transport.integration.test.ts
+++ b/tests/integration/http-transport.integration.test.ts
@@ -38,12 +38,13 @@ describe("HTTP transport integration", () => {
 		const transport = new StreamableHTTPClientTransport(url);
 		const client = new Client({ name: "test-client", version: "0.0.0" });
 		await client.connect(transport);
-
-		const result = await client.listTools();
-		expect(result).toHaveProperty("tools");
-		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools.find((t) => t.name === "noop")).toBeDefined();
-
-		await client.close();
+		try {
+			const result = await client.listTools();
+			expect(result).toHaveProperty("tools");
+			expect(Array.isArray(result.tools)).toBe(true);
+			expect(result.tools.find((t) => t.name === "noop")).toBeDefined();
+		} finally {
+			await client.close();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- Replaces the `createHttpServer` error stub (removed in v1.18.0) with a real `startHttpServer()` using `StreamableHTTPServerTransport` from `@modelcontextprotocol/sdk` v1.29.0 — no new dependencies
- Sessions are tracked per-connection (`Map<sessionId, { transport, server }>`); unknown session IDs return 404 to match SDK semantics
- `runServer()` branches on `--transport=http` (new) vs stdio (default); default port 3000

## Changes

- **`src/utils/config.ts`** — Added `transport` and `port` fields to `HevyConfig`; `parseConfig` handles `--transport=http|stdio` and `--port=N`
- **`src/utils/httpServer.ts`** — Full replacement: `startHttpServer(buildServer, port)` returns `Promise<http.Server>` for clean teardown
- **`src/index.ts`** — `runServer()` branches on transport mode
- **`src/utils/config.test.ts`** — Added `--transport` and `--port` parsing tests
- **`src/utils/httpServer.test.ts`** — Updated from deprecation-throw assertions to smoke test
- **`tests/integration/http-transport.integration.test.ts`** — Real transport test: starts server on port 0, connects `StreamableHTTPClientTransport`, calls `listTools()`
- **`README.md`** — Replaced "stdio only" deprecation notice with documentation for both transport modes

## Test plan

- [ ] `npm run check:types` — no TypeScript errors
- [ ] `npx vitest run --exclude tests/integration/**` — unit tests pass
- [ ] `npx vitest run tests/integration/http-transport.integration.test.ts` — transport test passes (no Hevy API key needed)
- [ ] Manual smoke test: `HEVY_API_KEY=xxx node dist/cli.mjs --transport=http --port=3000` then inspect with `npx @modelcontextprotocol/inspector http://localhost:3000/mcp`