### PR TITLE
feat: implement OAuth 2.1 HTTP transport (http+oauth)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,44 @@ Required environment variables:
 
 - `HEVY_API_KEY` - Hevy API key (required for server operation and integration tests)
 
+### HTTP+OAuth Transport
+
+The `http+oauth` transport exposes a password-gated OAuth 2.1 authorization server + MCP resource server, compatible with claude.ai Connectors.
+
+Additional environment variables (required for `http+oauth` mode):
+
+- `MCP_ISSUER_URL` - Public base URL of this server (e.g. `https://mcp.example.com`). Also settable via `--issuer-url=URL`.
+- `MCP_AUTH_PASSWORD` - Password shown in the consent form; leave empty to reject all logins.
+- `OAUTH_DB_PATH` - Path to the SQLite database file (default: `./oauth.db`).
+
+Starting the server:
+
+```bash
+MCP_ISSUER_URL=http://localhost:3000 MCP_AUTH_PASSWORD=secret HEVY_API_KEY=xxx \
+  node dist/cli.mjs --transport=http+oauth --port=3000
+```
+
+Verification:
+
+```bash
+# OAuth metadata
+curl http://localhost:3000/.well-known/oauth-authorization-server | jq .
+
+# Unauthenticated request should return 401
+curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" -d '{}'
+```
+
+#### Docker Compose
+
+`Dockerfile.oauth` and `docker-compose.yml` provide a self-contained deployment (port 8012 → 8000 inside container). The existing `Dockerfile` stub (which deliberately errors) and `docker.test.ts` are untouched.
+
+```bash
+# Create .env with HEVY_API_KEY, MCP_AUTH_PASSWORD, MCP_ISSUER_URL
+docker compose -f docker-compose.yml build
+docker compose -f docker-compose.yml up -d
+```
+
 ## Tool Implementation Pattern
 
 Each MCP tool follows this pattern:

--- a/Dockerfile.oauth
+++ b/Dockerfile.oauth
@@ -1,0 +1,8 @@
+FROM node:24-slim
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+EXPOSE 8000
+CMD ["node", "dist/cli.mjs", "--transport=http+oauth", "--port=8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  hevy-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile.oauth
+    ports:
+      - "8012:8000"
+    volumes:
+      - oauth-data:/data
+    environment:
+      - OAUTH_DB_PATH=/data/oauth.db
+    env_file: .env
+    networks:
+      - media_default
+
+volumes:
+  oauth-data:
+
+networks:
+  media_default:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,6 @@ services:
     environment:
       - OAUTH_DB_PATH=/data/oauth.db
     env_file: .env
-    networks:
-      - media_default
 
 volumes:
   oauth-data:
-
-networks:
-  media_default:
-    external: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@sentry/node": "^10.47.0",
 				"axios": "^1.14.0",
+				"better-sqlite3": "^12.8.0",
+				"express": "^5.2.1",
 				"zod": "^4.3.6"
 			},
 			"bin": {
@@ -35,7 +37,10 @@
 				"@semantic-release/npm": "^13.1.5",
 				"@semantic-release/release-notes-generator": "^14.1.0",
 				"@sentry/rollup-plugin": "^5.1.1",
+				"@types/better-sqlite3": "^7.6.13",
+				"@types/express": "^5.0.6",
 				"@types/node": "^25.5.2",
+				"@types/supertest": "^7.2.0",
 				"@vitest/coverage-v8": "^4.1.2",
 				"abstract-syntax-tree": "^2.22.0",
 				"cross-env": "^10.1.0",
@@ -45,6 +50,7 @@
 				"oxlint-tsgolint": "^0.20.0",
 				"semantic-release": "^25.0.3",
 				"semantic-release-unsquash": "^0.4.0",
+				"supertest": "^7.2.2",
 				"tsdown": "^0.21.7",
 				"tsx": "^4.21.0",
 				"typescript": "^6.0.2",
@@ -1729,6 +1735,19 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
+		"node_modules/@noble/hashes": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+			"integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
 		"node_modules/@octokit/auth-token": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
@@ -3122,6 +3141,16 @@
 			],
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@paralleldrive/cuid2": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+			"integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "^1.1.5"
 			}
 		},
 		"node_modules/@pnpm/config.env-replace": {
@@ -4901,6 +4930,27 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@types/better-sqlite3": {
+			"version": "7.6.13",
+			"resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+			"integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/body-parser": {
+			"version": "1.19.6",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+			"integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -4921,6 +4971,13 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/cookiejar": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+			"integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4935,6 +4992,38 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/express": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+			"integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^5.0.0",
+				"@types/serve-static": "^2"
+			}
+		},
+		"node_modules/@types/express-serve-static-core": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+			"integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*",
+				"@types/send": "*"
+			}
+		},
+		"node_modules/@types/http-errors": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+			"integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/jsesc": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
@@ -4946,6 +5035,13 @@
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/methods": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+			"integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/minimist": {
@@ -4998,6 +5094,65 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/pg": "*"
+			}
+		},
+		"node_modules/@types/qs": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/range-parser": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/serve-static": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+			"integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-errors": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/superagent": {
+			"version": "8.1.9",
+			"resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+			"integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/cookiejar": "^2.1.5",
+				"@types/methods": "^1.1.4",
+				"@types/node": "*",
+				"form-data": "^4.0.0"
+			}
+		},
+		"node_modules/@types/supertest": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+			"integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/methods": "^1.1.4",
+				"@types/superagent": "^8.1.0"
 			}
 		},
 		"node_modules/@types/tedious": {
@@ -5340,6 +5495,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5499,7 +5661,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5536,6 +5697,29 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/better-sqlite3": {
+			"version": "12.8.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+			"integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"prebuild-install": "^7.1.1"
+			},
+			"engines": {
+				"node": "20.x || 22.x || 23.x || 24.x || 25.x"
+			}
+		},
+		"node_modules/bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"license": "MIT",
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"node_modules/birpc": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
@@ -5550,7 +5734,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
 			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer": "^5.5.0",
@@ -5562,7 +5745,6 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -5667,7 +5849,6 @@
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
 			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5859,6 +6040,12 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"license": "ISC"
+		},
 		"node_modules/cjs-module-lexer": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
@@ -6047,6 +6234,16 @@
 				"dot-prop": "^5.1.0"
 			}
 		},
+		"node_modules/component-emitter": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+			"integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/compute-gcd": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
@@ -6218,6 +6415,13 @@
 			"engines": {
 				"node": ">=6.6.0"
 			}
+		},
+		"node_modules/cookiejar": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+			"integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
@@ -6435,11 +6639,25 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
@@ -6487,10 +6705,20 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
 			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/dezalgo": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+			"integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"asap": "^2.0.0",
+				"wrappy": "1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -6619,6 +6847,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
 			}
 		},
 		"node_modules/env-ci": {
@@ -7115,6 +7352,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"license": "(MIT OR WTFPL)",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -7317,6 +7563,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"license": "MIT"
+		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7455,6 +7707,24 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/formidable": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+			"integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@paralleldrive/cuid2": "^2.2.2",
+				"dezalgo": "^1.0.4",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/tunnckoCore/commissions"
+			}
+		},
 		"node_modules/forwarded": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7489,6 +7759,12 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
 			}
+		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"license": "MIT"
 		},
 		"node_modules/fs-extra": {
 			"version": "11.3.4",
@@ -7668,6 +7944,12 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+			"license": "MIT"
 		},
 		"node_modules/glob": {
 			"version": "13.0.6",
@@ -7966,7 +8248,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -9459,6 +9740,16 @@
 				"node": ">=10.4.0"
 			}
 		},
+		"node_modules/methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -9537,6 +9828,18 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9566,7 +9869,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -9606,6 +9908,12 @@
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"license": "MIT"
 		},
 		"node_modules/modify-values": {
 			"version": "1.0.1",
@@ -9679,6 +9987,12 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/napi-build-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+			"integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+			"license": "MIT"
+		},
 		"node_modules/negotiator": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -9707,6 +10021,18 @@
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
 			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
 			"license": "ISC"
+		},
+		"node_modules/node-abi": {
+			"version": "3.89.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+			"integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/node-emoji": {
 			"version": "2.2.0",
@@ -12577,6 +12903,33 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/prebuild-install": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+			"deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+			"license": "MIT",
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^2.0.0",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"bin": {
+				"prebuild-install": "bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/pretty-ms": {
 			"version": "9.3.0",
 			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -12636,6 +12989,16 @@
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"node_modules/pure-conditions": {
 			"version": "1.2.3",
@@ -12726,7 +13089,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
 			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"dependencies": {
 				"deep-extend": "^0.6.0",
@@ -12742,7 +13104,6 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/react-devtools-core": {
@@ -13519,7 +13880,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/safer-buffer": {
@@ -14623,6 +14983,51 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -14766,7 +15171,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
@@ -14844,7 +15248,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -14866,6 +15269,55 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/superagent": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+			"integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"component-emitter": "^1.3.1",
+				"cookiejar": "^2.1.4",
+				"debug": "^4.3.7",
+				"fast-safe-stringify": "^2.1.1",
+				"form-data": "^4.0.5",
+				"formidable": "^3.5.4",
+				"methods": "^1.1.2",
+				"mime": "2.6.0",
+				"qs": "^6.14.1"
+			},
+			"engines": {
+				"node": ">=14.18.0"
+			}
+		},
+		"node_modules/superagent/node_modules/mime": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/supertest": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+			"integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cookie-signature": "^1.2.2",
+				"methods": "^1.1.2",
+				"superagent": "^10.3.0"
+			},
+			"engines": {
+				"node": ">=14.18.0"
 			}
 		},
 		"node_modules/supports-color": {
@@ -14949,6 +15401,48 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tar-fs": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+			"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tar-stream/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/temp-dir": {
@@ -15308,6 +15802,18 @@
 				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
 			}
 		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/type": {
 			"version": "2.7.3",
 			"resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
@@ -15536,7 +16042,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/utility-types": {
@@ -15786,6 +16291,24 @@
 				"yaml": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vitest/node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/wcwidth": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@sentry/node": "^10.47.0",
 		"axios": "^1.14.0",
+		"better-sqlite3": "^12.8.0",
+		"express": "^5.2.1",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
@@ -75,7 +77,10 @@
 		"@semantic-release/npm": "^13.1.5",
 		"@semantic-release/release-notes-generator": "^14.1.0",
 		"@sentry/rollup-plugin": "^5.1.1",
+		"@types/better-sqlite3": "^7.6.13",
+		"@types/express": "^5.0.6",
 		"@types/node": "^25.5.2",
+		"@types/supertest": "^7.2.0",
 		"@vitest/coverage-v8": "^4.1.2",
 		"abstract-syntax-tree": "^2.22.0",
 		"cross-env": "^10.1.0",
@@ -85,6 +90,7 @@
 		"oxlint-tsgolint": "^0.20.0",
 		"semantic-release": "^25.0.3",
 		"semantic-release-unsquash": "^0.4.0",
+		"supertest": "^7.2.2",
 		"tsdown": "^0.21.7",
 		"tsx": "^4.21.0",
 		"typescript": "^6.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,8 +46,8 @@ import { registerRoutineTools } from "./tools/routines.js";
 import { registerTemplateTools } from "./tools/templates.js";
 import { registerWebhookTools } from "./tools/webhooks.js";
 import { registerWorkoutTools } from "./tools/workouts.js";
-import { assertApiKey, parseConfig } from "./utils/config.js";
-import { startHttpServer } from "./utils/httpServer.js";
+import { assertApiKey, assertIssuerUrl, parseConfig } from "./utils/config.js";
+import { startHttpServer, startOAuthHttpServer } from "./utils/httpServer.js";
 import { createClient } from "./utils/hevyClient.js";
 
 const HEVY_API_BASEURL = "https://api.hevyapp.com";
@@ -90,6 +90,21 @@ export default function createServer({ config }: { config: ServerConfig }) {
 export async function runServer() {
 	const args = process.argv.slice(2);
 	const cfg = parseConfig(args, process.env);
+
+	if (cfg.transport === "http+oauth") {
+		assertApiKey(cfg.apiKey);
+		assertIssuerUrl(cfg.issuerUrl);
+		const port = cfg.port ?? 3000;
+		console.error(`Starting MCP server in HTTP+OAuth mode on port ${port}`);
+		await startOAuthHttpServer(
+			() => buildServer(cfg.apiKey!),
+			port,
+			cfg.issuerUrl!,
+			"Hevy MCP Authorization",
+		);
+		return;
+	}
+
 	assertApiKey(cfg.apiKey);
 
 	if (cfg.transport === "http") {

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { parseConfig } from "./config.js";
+import { describe, expect, it, vi } from "vitest";
+import { assertIssuerUrl, parseConfig } from "./config.js";
 
 function env(vars: Record<string, string | undefined>): NodeJS.ProcessEnv {
 	return { ...process.env, ...vars } as NodeJS.ProcessEnv;
@@ -61,5 +61,47 @@ describe("parseConfig", () => {
 		expect(() => parseConfig(["--port=99999"], env({}))).toThrow(
 			/Invalid --port value/,
 		);
+	});
+
+	it("parses --transport=http+oauth", () => {
+		const cfg = parseConfig(["--transport=http+oauth"], env({}));
+		expect(cfg.transport).toBe("http+oauth");
+	});
+
+	it("parses --issuer-url=https://example.com", () => {
+		const cfg = parseConfig(["--issuer-url=https://example.com"], env({}));
+		expect(cfg.issuerUrl).toBe("https://example.com");
+	});
+
+	it("falls back to MCP_ISSUER_URL env var", () => {
+		const cfg = parseConfig(
+			[],
+			env({ MCP_ISSUER_URL: "https://env.example.com" }),
+		);
+		expect(cfg.issuerUrl).toBe("https://env.example.com");
+	});
+
+	it("CLI --issuer-url takes priority over MCP_ISSUER_URL env var", () => {
+		const cfg = parseConfig(
+			["--issuer-url=https://cli.example.com"],
+			env({ MCP_ISSUER_URL: "https://env.example.com" }),
+		);
+		expect(cfg.issuerUrl).toBe("https://cli.example.com");
+	});
+});
+
+describe("assertIssuerUrl", () => {
+	it("exits if issuer URL is undefined", () => {
+		const exitSpy = vi
+			.spyOn(process, "exit")
+			.mockImplementation((_code?: string | number | null) => {
+				throw new Error("process.exit called");
+			});
+		expect(() => assertIssuerUrl(undefined)).toThrow("process.exit called");
+		exitSpy.mockRestore();
+	});
+
+	it("does not throw when issuer URL is provided", () => {
+		expect(() => assertIssuerUrl("https://example.com")).not.toThrow();
 	});
 });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,7 +1,8 @@
 export interface HevyConfig {
 	apiKey?: string;
-	transport?: "stdio" | "http";
+	transport?: "stdio" | "http" | "http+oauth";
 	port?: number;
+	issuerUrl?: string;
 }
 
 /**
@@ -17,8 +18,9 @@ export function parseConfig(
 	env: NodeJS.ProcessEnv,
 ): HevyConfig {
 	let apiKey = "";
-	let transport: "stdio" | "http" | undefined;
+	let transport: "stdio" | "http" | "http+oauth" | undefined;
 	let port: number | undefined;
+	let issuerUrl: string | undefined;
 
 	const apiKeyArgPatterns = [
 		/^--hevy-api-key=(.+)$/i,
@@ -33,9 +35,12 @@ export function parseConfig(
 				break;
 			}
 		}
-		const transportMatch = raw.match(/^--transport=(stdio|http)$/i);
+		const transportMatch = raw.match(/^--transport=(stdio|http|http\+oauth)$/i);
 		if (transportMatch) {
-			transport = transportMatch[1].toLowerCase() as "stdio" | "http";
+			transport = transportMatch[1].toLowerCase() as
+				| "stdio"
+				| "http"
+				| "http+oauth";
 		}
 		const portMatch = raw.match(/^--port=(\d+)$/);
 		if (portMatch) {
@@ -47,15 +52,23 @@ export function parseConfig(
 			}
 			port = parsedPort;
 		}
+		const issuerMatch = raw.match(/^--issuer-url=(.+)$/i);
+		if (issuerMatch) {
+			issuerUrl = issuerMatch[1];
+		}
 	}
 	if (!apiKey) {
 		apiKey = env.HEVY_API_KEY || "";
+	}
+	if (!issuerUrl) {
+		issuerUrl = env.MCP_ISSUER_URL;
 	}
 
 	return {
 		apiKey,
 		transport,
 		port,
+		issuerUrl,
 	};
 }
 
@@ -65,6 +78,17 @@ export function assertApiKey(
 	if (!apiKey) {
 		console.error(
 			"Hevy API key is required. Provide it via the HEVY_API_KEY environment variable or the --hevy-api-key=YOUR_KEY command argument.",
+		);
+		process.exit(1);
+	}
+}
+
+export function assertIssuerUrl(
+	url: string | undefined,
+): asserts url is string {
+	if (!url) {
+		console.error(
+			"Issuer URL is required for http+oauth transport. Provide it via the MCP_ISSUER_URL environment variable or the --issuer-url=URL command argument.",
 		);
 		process.exit(1);
 	}

--- a/src/utils/consent.test.ts
+++ b/src/utils/consent.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { SQLiteOAuthProvider } from "./oauthProvider.js";
+import { createConsentRouter } from "./consent.js";
+
+process.env.OAUTH_DB_PATH = ":memory:";
+
+function makeApp(provider: SQLiteOAuthProvider) {
+	const app = express();
+	app.use(createConsentRouter(provider, "Test Auth"));
+	return app;
+}
+
+function makeClient(): OAuthClientInformationFull {
+	return {
+		client_id: "test-client",
+		client_id_issued_at: Math.floor(Date.now() / 1000),
+		redirect_uris: ["https://client.example.com/callback"],
+	};
+}
+
+async function seedSession(provider: SQLiteOAuthProvider): Promise<string> {
+	const client = makeClient();
+	const params = {
+		codeChallenge: "challenge",
+		redirectUri: "https://client.example.com/callback",
+		state: "mystate",
+		scopes: ["mcp"],
+	};
+	let sessionId = "";
+	const mockRes = {
+		redirect: (url: string) => {
+			sessionId = new URL(url).searchParams.get("session") ?? "";
+		},
+	} as unknown as import("express").Response;
+	await provider.authorize(client, params, mockRes);
+	return sessionId;
+}
+
+describe("GET /consent", () => {
+	it("renders form with session id", async () => {
+		const provider = new SQLiteOAuthProvider("https://example.com");
+		const app = makeApp(provider);
+		const sessionId = await seedSession(provider);
+		const res = await request(app).get(`/consent?session=${sessionId}`);
+		expect(res.status).toBe(200);
+		expect(res.text).toContain(sessionId);
+		expect(res.text).toContain("<form");
+	});
+
+	it("missing session returns 400", async () => {
+		const provider = new SQLiteOAuthProvider("https://example.com");
+		const app = makeApp(provider);
+		const res = await request(app).get("/consent");
+		expect(res.status).toBe(400);
+	});
+});
+
+describe("POST /consent", () => {
+	beforeEach(() => {
+		process.env.MCP_AUTH_PASSWORD = "correct-password";
+	});
+
+	afterEach(() => {
+		delete process.env.MCP_AUTH_PASSWORD;
+	});
+
+	it("correct password redirects with code and state", async () => {
+		const provider = new SQLiteOAuthProvider("https://example.com");
+		const app = makeApp(provider);
+		const sessionId = await seedSession(provider);
+
+		const res = await request(app)
+			.post("/consent")
+			.type("form")
+			.send({ session: sessionId, password: "correct-password" });
+
+		expect(res.status).toBe(302);
+		const location = new URL(res.headers["location"]);
+		expect(location.searchParams.get("code")).toBeTruthy();
+		expect(location.searchParams.get("state")).toBe("mystate");
+	});
+
+	it("wrong password returns 200 with error", async () => {
+		const provider = new SQLiteOAuthProvider("https://example.com");
+		const app = makeApp(provider);
+		const sessionId = await seedSession(provider);
+
+		const res = await request(app)
+			.post("/consent")
+			.type("form")
+			.send({ session: sessionId, password: "wrong" });
+
+		expect(res.status).toBe(200);
+		expect(res.text).toContain("Incorrect password");
+	});
+
+	it("empty MCP_AUTH_PASSWORD rejects all passwords", async () => {
+		process.env.MCP_AUTH_PASSWORD = "";
+		const provider = new SQLiteOAuthProvider("https://example.com");
+		const app = makeApp(provider);
+		const sessionId = await seedSession(provider);
+
+		const res = await request(app)
+			.post("/consent")
+			.type("form")
+			.send({ session: sessionId, password: "anything" });
+
+		expect(res.status).toBe(200);
+		expect(res.text).toContain("Incorrect password");
+	});
+
+	it("consumed session returns 400", async () => {
+		const provider = new SQLiteOAuthProvider("https://example.com");
+		const app = makeApp(provider);
+		const sessionId = await seedSession(provider);
+
+		// First consume the session
+		await request(app)
+			.post("/consent")
+			.type("form")
+			.send({ session: sessionId, password: "correct-password" });
+
+		// Second request with same session
+		const res = await request(app)
+			.post("/consent")
+			.type("form")
+			.send({ session: sessionId, password: "correct-password" });
+
+		expect(res.status).toBe(400);
+		expect(res.text).toContain("Session expired");
+	});
+});

--- a/src/utils/consent.ts
+++ b/src/utils/consent.ts
@@ -2,16 +2,27 @@ import { timingSafeEqual } from "node:crypto";
 import express from "express";
 import type { SQLiteOAuthProvider } from "./oauthProvider.js";
 
+const SESSION_ID_RE = /^[0-9a-f]{32}$/i;
+
+function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#x27;");
+}
+
 function renderForm(sessionId: string, title: string, error?: string): string {
 	const errorHtml = error
-		? `<p style="color:#dc2626;margin:0 0 12px;">${error}</p>`
+		? `<p style="color:#dc2626;margin:0 0 12px;">${escapeHtml(error)}</p>`
 		: "";
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>${title}</title>
+<title>${escapeHtml(title)}</title>
 <style>
 *{box-sizing:border-box}
 body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
@@ -30,10 +41,10 @@ button:hover{background:#2563eb}
 </head>
 <body>
 <div class="card">
-<h1>${title}</h1>
+<h1>${escapeHtml(title)}</h1>
 ${errorHtml}
 <form method="POST" action="/consent">
-<input type="hidden" name="session" value="${sessionId}"/>
+<input type="hidden" name="session" value="${escapeHtml(sessionId)}"/>
 <label for="password">Password</label>
 <input type="password" id="password" name="password" autofocus/>
 <button type="submit">Authorize</button>
@@ -51,8 +62,12 @@ export function createConsentRouter(
 
 	router.get("/consent", (req, res) => {
 		const session = req.query["session"];
-		if (!session || typeof session !== "string") {
-			res.status(400).send("Missing session parameter");
+		if (
+			!session ||
+			typeof session !== "string" ||
+			!SESSION_ID_RE.test(session)
+		) {
+			res.status(400).send("Invalid or missing session parameter");
 			return;
 		}
 		res.send(renderForm(session, title));
@@ -67,8 +82,8 @@ export function createConsentRouter(
 			const provided =
 				typeof req.body?.password === "string" ? req.body.password : "";
 
-			if (!session) {
-				res.status(400).send("Missing session parameter");
+			if (!session || !SESSION_ID_RE.test(session)) {
+				res.status(400).send("Invalid or missing session parameter");
 				return;
 			}
 
@@ -78,12 +93,10 @@ export function createConsentRouter(
 				return;
 			}
 
-			// Constant-time comparison with same-length buffers
-			const a = Buffer.alloc(expected.length);
-			Buffer.from(expected).copy(a);
-			const b = Buffer.alloc(expected.length);
-			Buffer.from(provided).copy(b);
-			if (!timingSafeEqual(a, b)) {
+			// Exact-length constant-time comparison — different lengths always fail
+			const a = Buffer.from(expected);
+			const b = Buffer.from(provided);
+			if (a.length !== b.length || !timingSafeEqual(a, b)) {
 				res.send(renderForm(session, title, "Incorrect password"));
 				return;
 			}

--- a/src/utils/consent.ts
+++ b/src/utils/consent.ts
@@ -1,0 +1,109 @@
+import { timingSafeEqual } from "node:crypto";
+import express from "express";
+import type { SQLiteOAuthProvider } from "./oauthProvider.js";
+
+function renderForm(sessionId: string, title: string, error?: string): string {
+	const errorHtml = error
+		? `<p style="color:#dc2626;margin:0 0 12px;">${error}</p>`
+		: "";
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>${title}</title>
+<style>
+*{box-sizing:border-box}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+background:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
+.card{background:#fff;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,.1);
+padding:32px;width:100%;max-width:380px}
+h1{margin:0 0 24px;font-size:1.25rem;font-weight:600;color:#111}
+label{display:block;margin-bottom:6px;font-size:.875rem;color:#374151}
+input[type=password]{width:100%;padding:8px 12px;border:1px solid #d1d5db;border-radius:6px;
+font-size:1rem;outline:none}
+input[type=password]:focus{border-color:#3b82f6;box-shadow:0 0 0 2px rgba(59,130,246,.25)}
+button{margin-top:16px;width:100%;padding:10px;background:#3b82f6;color:#fff;border:none;
+border-radius:6px;font-size:1rem;cursor:pointer}
+button:hover{background:#2563eb}
+</style>
+</head>
+<body>
+<div class="card">
+<h1>${title}</h1>
+${errorHtml}
+<form method="POST" action="/consent">
+<input type="hidden" name="session" value="${sessionId}"/>
+<label for="password">Password</label>
+<input type="password" id="password" name="password" autofocus/>
+<button type="submit">Authorize</button>
+</form>
+</div>
+</body>
+</html>`;
+}
+
+export function createConsentRouter(
+	provider: SQLiteOAuthProvider,
+	title: string,
+): express.Router {
+	const router = express.Router();
+
+	router.get("/consent", (req, res) => {
+		const session = req.query["session"];
+		if (!session || typeof session !== "string") {
+			res.status(400).send("Missing session parameter");
+			return;
+		}
+		res.send(renderForm(session, title));
+	});
+
+	router.post(
+		"/consent",
+		express.urlencoded({ extended: false }),
+		(req, res) => {
+			const session =
+				typeof req.body?.session === "string" ? req.body.session : "";
+			const provided =
+				typeof req.body?.password === "string" ? req.body.password : "";
+
+			if (!session) {
+				res.status(400).send("Missing session parameter");
+				return;
+			}
+
+			const expected = process.env.MCP_AUTH_PASSWORD ?? "";
+			if (!expected) {
+				res.send(renderForm(session, title, "Incorrect password"));
+				return;
+			}
+
+			// Constant-time comparison with same-length buffers
+			const a = Buffer.alloc(expected.length);
+			Buffer.from(expected).copy(a);
+			const b = Buffer.alloc(expected.length);
+			Buffer.from(provided).copy(b);
+			if (!timingSafeEqual(a, b)) {
+				res.send(renderForm(session, title, "Incorrect password"));
+				return;
+			}
+
+			const pending = provider.popPendingSession(session);
+			if (!pending) {
+				res.status(400).send("Session expired or not found");
+				return;
+			}
+
+			const { client, params } = pending;
+			const code = provider.createAuthorizationCode(client.client_id, params);
+
+			const redirectUrl = new URL(params.redirectUri);
+			redirectUrl.searchParams.set("code", code);
+			if (params.state) redirectUrl.searchParams.set("state", params.state);
+
+			res.redirect(302, redirectUrl.toString());
+		},
+	);
+
+	return router;
+}

--- a/src/utils/httpServer.oauth.test.ts
+++ b/src/utils/httpServer.oauth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import express from "express";
 import request from "supertest";
 import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
@@ -6,8 +6,22 @@ import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middlew
 import { SQLiteOAuthProvider } from "./oauthProvider.js";
 
 process.env.OAUTH_DB_PATH = ":memory:";
-// Required to allow HTTP issuer URLs in tests
-process.env.MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL = "true";
+
+let originalAllowInsecure: string | undefined;
+
+beforeAll(() => {
+	originalAllowInsecure = process.env.MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL;
+	process.env.MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL = "true";
+});
+
+afterAll(() => {
+	if (originalAllowInsecure === undefined) {
+		delete process.env.MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL;
+	} else {
+		process.env.MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL =
+			originalAllowInsecure;
+	}
+});
 
 function makeApp() {
 	const provider = new SQLiteOAuthProvider("http://localhost");

--- a/src/utils/httpServer.oauth.test.ts
+++ b/src/utils/httpServer.oauth.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+import { SQLiteOAuthProvider } from "./oauthProvider.js";
+
+process.env.OAUTH_DB_PATH = ":memory:";
+// Required to allow HTTP issuer URLs in tests
+process.env.MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL = "true";
+
+function makeApp() {
+	const provider = new SQLiteOAuthProvider("http://localhost");
+	const app = express();
+	app.use(
+		mcpAuthRouter({
+			provider,
+			issuerUrl: new URL("http://localhost"),
+			resourceServerUrl: new URL("http://localhost/mcp"),
+		}),
+	);
+	app.post("/mcp", requireBearerAuth({ verifier: provider }), (_req, res) => {
+		res.json({ ok: true });
+	});
+	return app;
+}
+
+describe("OAuth HTTP server", () => {
+	it("unauthenticated POST /mcp returns 401 with WWW-Authenticate: Bearer", async () => {
+		const app = makeApp();
+		const res = await request(app)
+			.post("/mcp")
+			.set("Content-Type", "application/json")
+			.send("{}");
+		expect(res.status).toBe(401);
+		expect(res.headers["www-authenticate"]).toMatch(/^Bearer/i);
+	});
+
+	it("GET /.well-known/oauth-authorization-server returns 200 with JSON metadata", async () => {
+		const app = makeApp();
+		const res = await request(app).get(
+			"/.well-known/oauth-authorization-server",
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers["content-type"]).toMatch(/json/);
+		const body = res.body as Record<string, unknown>;
+		expect(body.issuer).toBeTruthy();
+		expect(body.authorization_endpoint).toBeTruthy();
+		expect(body.token_endpoint).toBeTruthy();
+	});
+});

--- a/src/utils/httpServer.ts
+++ b/src/utils/httpServer.ts
@@ -195,22 +195,18 @@ export function startOAuthHttpServer(
 					return;
 				}
 
-				res
-					.status(404)
-					.json({
-						jsonrpc: "2.0",
-						error: { code: -32000, message: "Session not found" },
-						id: null,
-					});
+				res.status(404).json({
+					jsonrpc: "2.0",
+					error: { code: -32000, message: "Session not found" },
+					id: null,
+				});
 			} catch {
 				if (!res.headersSent) {
-					res
-						.status(500)
-						.json({
-							jsonrpc: "2.0",
-							error: { code: -32603, message: "Internal error" },
-							id: null,
-						});
+					res.status(500).json({
+						jsonrpc: "2.0",
+						error: { code: -32603, message: "Internal error" },
+						id: null,
+					});
 				}
 			}
 		},

--- a/src/utils/httpServer.ts
+++ b/src/utils/httpServer.ts
@@ -147,6 +147,8 @@ export function startOAuthHttpServer(
 	const app = express();
 	const sessions = new Map<string, Session>();
 
+	app.use(express.json({ limit: MAX_BODY_BYTES }));
+
 	app.use(
 		mcpAuthRouter({
 			provider,

--- a/src/utils/httpServer.ts
+++ b/src/utils/httpServer.ts
@@ -8,6 +8,11 @@ import {
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import express from "express";
+import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+import { SQLiteOAuthProvider } from "./oauthProvider.js";
+import { createConsentRouter } from "./consent.js";
 
 const MAX_BODY_BYTES = 1024 * 1024; // 1 MiB
 
@@ -129,5 +134,93 @@ export function startHttpServer(
 	return new Promise((resolve, reject) => {
 		httpServer.listen(port, () => resolve(httpServer));
 		httpServer.on("error", reject);
+	});
+}
+
+export function startOAuthHttpServer(
+	buildMcpServer: () => McpServer,
+	port: number,
+	issuerUrl: string,
+	title: string,
+): Promise<void> {
+	const provider = new SQLiteOAuthProvider(issuerUrl);
+	const app = express();
+	const sessions = new Map<string, Session>();
+
+	app.use(
+		mcpAuthRouter({
+			provider,
+			issuerUrl: new URL(issuerUrl),
+			resourceServerUrl: new URL(`${issuerUrl}/mcp`),
+		}),
+	);
+
+	app.use(createConsentRouter(provider, title));
+
+	app.all(
+		"/mcp",
+		requireBearerAuth({ verifier: provider }),
+		async (req, res) => {
+			try {
+				const sessionIdHeader = req.headers["mcp-session-id"];
+				const sessionId = Array.isArray(sessionIdHeader)
+					? sessionIdHeader[0]
+					: sessionIdHeader;
+
+				if (sessionId && sessions.has(sessionId)) {
+					await sessions
+						.get(sessionId)!
+						.transport.handleRequest(req, res, req.body);
+					return;
+				}
+
+				if (
+					!sessionId &&
+					req.method === "POST" &&
+					isInitializeRequest(req.body)
+				) {
+					let mcpServer: McpServer;
+					const transport = new StreamableHTTPServerTransport({
+						sessionIdGenerator: () => randomUUID(),
+						onsessioninitialized: (id) => {
+							sessions.set(id, { transport, server: mcpServer });
+						},
+					});
+					transport.onclose = () => {
+						if (transport.sessionId) sessions.delete(transport.sessionId);
+					};
+					mcpServer = buildMcpServer();
+					await mcpServer.connect(transport);
+					await transport.handleRequest(req, res, req.body);
+					return;
+				}
+
+				res
+					.status(404)
+					.json({
+						jsonrpc: "2.0",
+						error: { code: -32000, message: "Session not found" },
+						id: null,
+					});
+			} catch {
+				if (!res.headersSent) {
+					res
+						.status(500)
+						.json({
+							jsonrpc: "2.0",
+							error: { code: -32603, message: "Internal error" },
+							id: null,
+						});
+				}
+			}
+		},
+	);
+
+	return new Promise((resolve, reject) => {
+		const server = app.listen(port, () => {
+			console.error(`OAuth HTTP server listening on port ${port}`);
+			resolve();
+		});
+		server.on("error", reject);
 	});
 }

--- a/src/utils/oauthProvider.test.ts
+++ b/src/utils/oauthProvider.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+import { InvalidScopeError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import { SQLiteOAuthProvider } from "./oauthProvider.js";
+import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+// Use in-memory SQLite for tests
+process.env.OAUTH_DB_PATH = ":memory:";
+
+function makeProvider() {
+	return new SQLiteOAuthProvider("https://example.com");
+}
+
+function makeClient(
+	overrides?: Partial<OAuthClientInformationFull>,
+): OAuthClientInformationFull {
+	return {
+		client_id: "test-client",
+		client_id_issued_at: Math.floor(Date.now() / 1000),
+		redirect_uris: ["https://client.example.com/callback"],
+		...overrides,
+	};
+}
+
+describe("SQLiteOAuthProvider - clients store", () => {
+	it("registers and retrieves a client", async () => {
+		const provider = makeProvider();
+		const registered = await provider.clientsStore.registerClient!({
+			redirect_uris: ["https://client.example.com/callback"],
+		});
+		expect(registered.client_id).toBeTruthy();
+		const retrieved = await provider.clientsStore.getClient(
+			registered.client_id,
+		);
+		expect(retrieved).toMatchObject({ client_id: registered.client_id });
+	});
+
+	it("returns undefined for unknown client", () => {
+		const provider = makeProvider();
+		expect(provider.clientsStore.getClient("nonexistent")).toBeUndefined();
+	});
+});
+
+describe("SQLiteOAuthProvider - authorize", () => {
+	it("redirects to consent URL and stores pending session", async () => {
+		const provider = makeProvider();
+		const client = makeClient();
+		const params = {
+			codeChallenge: "abc123",
+			redirectUri: "https://client.example.com/callback",
+			scopes: ["mcp"],
+		};
+
+		const redirectCalls: string[] = [];
+		const mockRes = {
+			redirect: (url: string) => {
+				redirectCalls.push(url);
+			},
+		} as unknown as import("express").Response;
+
+		await provider.authorize(client, params, mockRes);
+		expect(redirectCalls).toHaveLength(1);
+		expect(redirectCalls[0]).toMatch(
+			/^https:\/\/example\.com\/consent\?session=[0-9a-f]{32}$/,
+		);
+	});
+
+	it("popPendingSession is consumed-once", async () => {
+		const provider = makeProvider();
+		const client = makeClient();
+		const params = {
+			codeChallenge: "abc123",
+			redirectUri: "https://client.example.com/callback",
+		};
+
+		let capturedSession = "";
+		const mockRes = {
+			redirect: (url: string) => {
+				capturedSession = new URL(url).searchParams.get("session") ?? "";
+			},
+		} as unknown as import("express").Response;
+
+		await provider.authorize(client, params, mockRes);
+		const first = provider.popPendingSession(capturedSession);
+		expect(first).toBeDefined();
+		const second = provider.popPendingSession(capturedSession);
+		expect(second).toBeUndefined();
+	});
+});
+
+describe("SQLiteOAuthProvider - auth codes", () => {
+	it("creates code and returns challenge", async () => {
+		const provider = makeProvider();
+		const client = makeClient();
+		const params = {
+			codeChallenge: "challenge-xyz",
+			redirectUri: "https://client.example.com/callback",
+		};
+
+		const code = provider.createAuthorizationCode(client.client_id, params);
+		expect(code).toBeTruthy();
+
+		const challenge = await provider.challengeForAuthorizationCode(
+			client,
+			code,
+		);
+		expect(challenge).toBe("challenge-xyz");
+	});
+
+	it("expired code throws on exchange", async () => {
+		const provider = makeProvider();
+		const client = makeClient();
+		const params = {
+			codeChallenge: "challenge",
+			redirectUri: "https://client.example.com/callback",
+		};
+		const code = provider.createAuthorizationCode(client.client_id, params);
+
+		// Manually expire by manipulating DB via internal access (simulate via time skip)
+		// We can't easily manipulate time, but we can verify the code was inserted
+		// and test the normal exchange path works when not expired
+		const tokens = await provider.exchangeAuthorizationCode(
+			client,
+			code,
+			undefined,
+			"https://client.example.com/callback",
+		);
+		expect(tokens.access_token).toBeTruthy();
+	});
+
+	it("mismatched client on code exchange throws", async () => {
+		const provider = makeProvider();
+		const client = makeClient();
+		const params = {
+			codeChallenge: "challenge",
+			redirectUri: "https://client.example.com/callback",
+		};
+		const code = provider.createAuthorizationCode(client.client_id, params);
+
+		const wrongClient = makeClient({ client_id: "wrong-client" });
+		await expect(
+			provider.exchangeAuthorizationCode(wrongClient, code),
+		).rejects.toThrow();
+	});
+
+	it("consumed code throws on second exchange", async () => {
+		const provider = makeProvider();
+		const client = makeClient();
+		const params = {
+			codeChallenge: "challenge",
+			redirectUri: "https://client.example.com/callback",
+		};
+		const code = provider.createAuthorizationCode(client.client_id, params);
+		await provider.exchangeAuthorizationCode(client, code);
+		await expect(
+			provider.exchangeAuthorizationCode(client, code),
+		).rejects.toThrow();
+	});
+});
+
+describe("SQLiteOAuthProvider - token exchange", () => {
+	async function getTokens(provider: SQLiteOAuthProvider) {
+		const client = makeClient();
+		const params = {
+			codeChallenge: "challenge",
+			redirectUri: "https://client.example.com/callback",
+			scopes: ["mcp"],
+		};
+		const code = provider.createAuthorizationCode(client.client_id, params);
+		return {
+			client,
+			tokens: await provider.exchangeAuthorizationCode(client, code),
+		};
+	}
+
+	it("returns tokens with correct expires_in", async () => {
+		const provider = makeProvider();
+		const { tokens } = await getTokens(provider);
+		expect(tokens.token_type).toBe("bearer");
+		expect(tokens.expires_in).toBe(3600);
+		expect(tokens.refresh_token).toBeTruthy();
+	});
+
+	it("verifyAccessToken returns AuthInfo with expiresAt", async () => {
+		const provider = makeProvider();
+		const { tokens } = await getTokens(provider);
+		const info = await provider.verifyAccessToken(tokens.access_token);
+		expect(info.token).toBe(tokens.access_token);
+		expect(info.clientId).toBe("test-client");
+		expect(typeof info.expiresAt).toBe("number");
+	});
+
+	it("expired access token throws", async () => {
+		const provider = makeProvider();
+		// Directly insert expired token
+		(provider as unknown as { db: import("better-sqlite3").Database }).db
+			.prepare(
+				`INSERT INTO access_tokens (token, client_id, scopes, expires_at, resource, family_id)
+				VALUES (?, ?, ?, ?, ?, ?)`,
+			)
+			.run("expired-tok", "test-client", '["mcp"]', 1, null, "fam1");
+		await expect(provider.verifyAccessToken("expired-tok")).rejects.toThrow();
+	});
+
+	it("refresh token rotation produces same family_id", async () => {
+		const provider = makeProvider();
+		const { client, tokens } = await getTokens(provider);
+		const newTokens = await provider.exchangeRefreshToken(
+			client,
+			tokens.refresh_token!,
+		);
+		expect(newTokens.access_token).not.toBe(tokens.access_token);
+		expect(newTokens.refresh_token).not.toBe(tokens.refresh_token);
+		// Old refresh token should be gone
+		await expect(
+			provider.exchangeRefreshToken(client, tokens.refresh_token!),
+		).rejects.toThrow();
+	});
+
+	it("scope escalation throws InvalidScopeError", async () => {
+		const provider = makeProvider();
+		const { client, tokens } = await getTokens(provider);
+		await expect(
+			provider.exchangeRefreshToken(client, tokens.refresh_token!, [
+				"mcp",
+				"admin",
+			]),
+		).rejects.toThrow(InvalidScopeError);
+	});
+});
+
+describe("SQLiteOAuthProvider - revocation", () => {
+	async function setup() {
+		const provider = makeProvider();
+		const client = makeClient();
+		const params = {
+			codeChallenge: "challenge",
+			redirectUri: "https://client.example.com/callback",
+			scopes: ["mcp"],
+		};
+		const code = provider.createAuthorizationCode(client.client_id, params);
+		const tokens = await provider.exchangeAuthorizationCode(client, code);
+		return { provider, client, tokens };
+	}
+
+	it("revocation via access token kills entire family", async () => {
+		const { provider, client, tokens } = await setup();
+		await provider.revokeToken!(client, { token: tokens.access_token });
+		await expect(
+			provider.verifyAccessToken(tokens.access_token),
+		).rejects.toThrow();
+		// refresh should also be gone
+		await expect(
+			provider.exchangeRefreshToken(client, tokens.refresh_token!),
+		).rejects.toThrow();
+	});
+
+	it("revocation via refresh token kills entire family", async () => {
+		const { provider, client, tokens } = await setup();
+		await provider.revokeToken!(client, { token: tokens.refresh_token! });
+		await expect(
+			provider.verifyAccessToken(tokens.access_token),
+		).rejects.toThrow();
+	});
+
+	it("revoke nonexistent token is no-op", async () => {
+		const { provider, client } = await setup();
+		await expect(
+			provider.revokeToken!(client, { token: "nonexistent" }),
+		).resolves.toBeUndefined();
+	});
+});

--- a/src/utils/oauthProvider.test.ts
+++ b/src/utils/oauthProvider.test.ts
@@ -115,16 +115,14 @@ describe("SQLiteOAuthProvider - auth codes", () => {
 		};
 		const code = provider.createAuthorizationCode(client.client_id, params);
 
-		// Manually expire by manipulating DB via internal access (simulate via time skip)
-		// We can't easily manipulate time, but we can verify the code was inserted
-		// and test the normal exchange path works when not expired
-		const tokens = await provider.exchangeAuthorizationCode(
-			client,
-			code,
-			undefined,
-			"https://client.example.com/callback",
-		);
-		expect(tokens.access_token).toBeTruthy();
+		// Force expiry by back-dating the row in the DB
+		(provider as unknown as { db: import("better-sqlite3").Database }).db
+			.prepare("UPDATE auth_codes SET expires_at = 1 WHERE code = ?")
+			.run(code);
+
+		await expect(
+			provider.exchangeAuthorizationCode(client, code),
+		).rejects.toThrow(/expired/i);
 	});
 
 	it("mismatched client on code exchange throws", async () => {

--- a/src/utils/oauthProvider.ts
+++ b/src/utils/oauthProvider.ts
@@ -21,10 +21,14 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 const ACCESS_TOKEN_TTL = 3600;
 const REFRESH_TOKEN_TTL = 30 * 86400;
 const AUTH_CODE_TTL = 300;
+// Pending sessions expire after 10 minutes; cleaned up lazily on each authorize()
+const PENDING_SESSION_TTL_MS = 10 * 60 * 1000;
+const MAX_PENDING_SESSIONS = 1000;
 
 type PendingSession = {
 	client: OAuthClientInformationFull;
 	params: AuthorizationParams;
+	expiresAt: number;
 };
 
 export class SQLiteOAuthProvider implements OAuthServerProvider {
@@ -109,14 +113,32 @@ export class SQLiteOAuthProvider implements OAuthServerProvider {
 		params: AuthorizationParams,
 		res: Response,
 	): Promise<void> {
+		this.evictExpiredSessions();
+		if (this.pendingSessions.size >= MAX_PENDING_SESSIONS) {
+			// Evict the oldest entry to enforce the size cap
+			const oldest = this.pendingSessions.keys().next().value;
+			if (oldest) this.pendingSessions.delete(oldest);
+		}
 		const sessionId = randomBytes(16).toString("hex");
-		this.pendingSessions.set(sessionId, { client, params });
+		this.pendingSessions.set(sessionId, {
+			client,
+			params,
+			expiresAt: Date.now() + PENDING_SESSION_TTL_MS,
+		});
 		res.redirect(`${this.issuerUrl}/consent?session=${sessionId}`);
+	}
+
+	private evictExpiredSessions(): void {
+		const now = Date.now();
+		for (const [id, session] of this.pendingSessions) {
+			if (session.expiresAt <= now) this.pendingSessions.delete(id);
+		}
 	}
 
 	popPendingSession(id: string): PendingSession | undefined {
 		const session = this.pendingSessions.get(id);
 		this.pendingSessions.delete(id);
+		if (!session || session.expiresAt <= Date.now()) return undefined;
 		return session;
 	}
 
@@ -182,54 +204,59 @@ export class SQLiteOAuthProvider implements OAuthServerProvider {
 			throw new InvalidGrantError("Authorization code expired");
 		if (row.client_id !== client.client_id)
 			throw new InvalidGrantError("Client mismatch");
-
-		this.db
-			.prepare("DELETE FROM auth_codes WHERE code = ?")
-			.run(authorizationCode);
-
 		if (redirectUri && redirectUri !== row.redirect_uri)
 			throw new InvalidGrantError("Redirect URI mismatch");
 
+		// All validations pass — consume code and mint tokens atomically
 		const storedScopes: string[] = JSON.parse(row.scopes);
-		const familyId = randomUUID();
-		const accessTok = randomBytes(32).toString("hex");
-		const refreshTok = randomBytes(32).toString("hex");
-		const now = Math.floor(Date.now() / 1000);
 		const resourceStr = resource?.toString() ?? row.resource ?? null;
 
-		this.db
-			.prepare(
-				`INSERT INTO access_tokens (token, client_id, scopes, expires_at, resource, family_id)
-				VALUES (?, ?, ?, ?, ?, ?)`,
-			)
-			.run(
-				accessTok,
-				client.client_id,
-				JSON.stringify(storedScopes),
-				now + ACCESS_TOKEN_TTL,
-				resourceStr,
-				familyId,
-			);
-		this.db
-			.prepare(
-				`INSERT INTO refresh_tokens (token, client_id, scopes, expires_at, family_id)
-				VALUES (?, ?, ?, ?, ?)`,
-			)
-			.run(
-				refreshTok,
-				client.client_id,
-				JSON.stringify(storedScopes),
-				now + REFRESH_TOKEN_TTL,
-				familyId,
-			);
+		return this.db.transaction((): OAuthTokens => {
+			const deleted = this.db
+				.prepare("DELETE FROM auth_codes WHERE code = ?")
+				.run(authorizationCode);
+			if (deleted.changes === 0)
+				throw new InvalidGrantError("Authorization code already used");
 
-		return {
-			access_token: accessTok,
-			token_type: "bearer",
-			expires_in: ACCESS_TOKEN_TTL,
-			scope: storedScopes.join(" "),
-			refresh_token: refreshTok,
-		};
+			const familyId = randomUUID();
+			const accessTok = randomBytes(32).toString("hex");
+			const refreshTok = randomBytes(32).toString("hex");
+			const now = Math.floor(Date.now() / 1000);
+
+			this.db
+				.prepare(
+					`INSERT INTO access_tokens (token, client_id, scopes, expires_at, resource, family_id)
+					VALUES (?, ?, ?, ?, ?, ?)`,
+				)
+				.run(
+					accessTok,
+					client.client_id,
+					JSON.stringify(storedScopes),
+					now + ACCESS_TOKEN_TTL,
+					resourceStr,
+					familyId,
+				);
+			this.db
+				.prepare(
+					`INSERT INTO refresh_tokens (token, client_id, scopes, expires_at, family_id)
+					VALUES (?, ?, ?, ?, ?)`,
+				)
+				.run(
+					refreshTok,
+					client.client_id,
+					JSON.stringify(storedScopes),
+					now + REFRESH_TOKEN_TTL,
+					familyId,
+				);
+
+			return {
+				access_token: accessTok,
+				token_type: "bearer",
+				expires_in: ACCESS_TOKEN_TTL,
+				scope: storedScopes.join(" "),
+				refresh_token: refreshTok,
+			};
+		})();
 	}
 
 	async exchangeRefreshToken(
@@ -238,45 +265,50 @@ export class SQLiteOAuthProvider implements OAuthServerProvider {
 		scopes?: string[],
 		_resource?: URL,
 	): Promise<OAuthTokens> {
-		const row = this.db
-			.prepare(
-				`SELECT client_id, scopes, expires_at, family_id
-				FROM refresh_tokens WHERE token = ?`,
-			)
-			.get(refreshToken) as
-			| {
-					client_id: string;
-					scopes: string;
-					expires_at: number;
-					family_id: string;
-			  }
-			| undefined;
+		// Load, validate, rotate — all inside one transaction to prevent
+		// concurrent use of the same refresh token producing multiple new tokens.
+		return this.db.transaction((): OAuthTokens => {
+			const row = this.db
+				.prepare(
+					`SELECT client_id, scopes, expires_at, family_id
+					FROM refresh_tokens WHERE token = ?`,
+				)
+				.get(refreshToken) as
+				| {
+						client_id: string;
+						scopes: string;
+						expires_at: number;
+						family_id: string;
+				  }
+				| undefined;
 
-		if (!row) throw new InvalidGrantError("Refresh token not found");
-		if (row.expires_at < Math.floor(Date.now() / 1000))
-			throw new InvalidGrantError("Refresh token expired");
-		if (row.client_id !== client.client_id)
-			throw new InvalidGrantError("Client mismatch");
+			if (!row) throw new InvalidGrantError("Refresh token not found");
+			if (row.expires_at < Math.floor(Date.now() / 1000))
+				throw new InvalidGrantError("Refresh token expired");
+			if (row.client_id !== client.client_id)
+				throw new InvalidGrantError("Client mismatch");
 
-		const storedScopes: string[] = JSON.parse(row.scopes);
-		if (scopes?.length) {
-			const invalid = scopes.filter((s) => !storedScopes.includes(s));
-			if (invalid.length)
-				throw new InvalidScopeError(
-					`Requested scopes exceed granted scopes: ${invalid.join(", ")}`,
-				);
-		}
+			const storedScopes: string[] = JSON.parse(row.scopes);
+			if (scopes?.length) {
+				const invalid = scopes.filter((s) => !storedScopes.includes(s));
+				if (invalid.length)
+					throw new InvalidScopeError(
+						`Requested scopes exceed granted scopes: ${invalid.join(", ")}`,
+					);
+			}
 
-		const effectiveScopes = scopes?.length ? scopes : storedScopes;
-		const now = Math.floor(Date.now() / 1000);
-		const newFamilyId = row.family_id; // same family
-		const accessTok = randomBytes(32).toString("hex");
-		const refreshTok = randomBytes(32).toString("hex");
+			const effectiveScopes = scopes?.length ? scopes : storedScopes;
+			const now = Math.floor(Date.now() / 1000);
+			const familyId = row.family_id;
+			const accessTok = randomBytes(32).toString("hex");
+			const refreshTok = randomBytes(32).toString("hex");
 
-		const rotate = this.db.transaction(() => {
-			this.db
+			const deleted = this.db
 				.prepare("DELETE FROM refresh_tokens WHERE token = ?")
 				.run(refreshToken);
+			if (deleted.changes === 0)
+				throw new InvalidGrantError("Refresh token already used");
+
 			this.db
 				.prepare(
 					`INSERT INTO access_tokens (token, client_id, scopes, expires_at, resource, family_id)
@@ -288,7 +320,7 @@ export class SQLiteOAuthProvider implements OAuthServerProvider {
 					JSON.stringify(effectiveScopes),
 					now + ACCESS_TOKEN_TTL,
 					null,
-					newFamilyId,
+					familyId,
 				);
 			this.db
 				.prepare(
@@ -300,18 +332,17 @@ export class SQLiteOAuthProvider implements OAuthServerProvider {
 					client.client_id,
 					JSON.stringify(effectiveScopes),
 					now + REFRESH_TOKEN_TTL,
-					newFamilyId,
+					familyId,
 				);
-		});
-		rotate();
 
-		return {
-			access_token: accessTok,
-			token_type: "bearer",
-			expires_in: ACCESS_TOKEN_TTL,
-			scope: effectiveScopes.join(" "),
-			refresh_token: refreshTok,
-		};
+			return {
+				access_token: accessTok,
+				token_type: "bearer",
+				expires_in: ACCESS_TOKEN_TTL,
+				scope: effectiveScopes.join(" "),
+				refresh_token: refreshTok,
+			};
+		})();
 	}
 
 	async verifyAccessToken(token: string): Promise<AuthInfo> {

--- a/src/utils/oauthProvider.ts
+++ b/src/utils/oauthProvider.ts
@@ -1,0 +1,371 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import Database from "better-sqlite3";
+import type {
+	OAuthClientInformationFull,
+	OAuthTokenRevocationRequest,
+	OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { Response } from "express";
+import {
+	InvalidGrantError,
+	InvalidScopeError,
+	InvalidTokenError,
+} from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type {
+	AuthorizationParams,
+	OAuthServerProvider,
+} from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+
+const ACCESS_TOKEN_TTL = 3600;
+const REFRESH_TOKEN_TTL = 30 * 86400;
+const AUTH_CODE_TTL = 300;
+
+type PendingSession = {
+	client: OAuthClientInformationFull;
+	params: AuthorizationParams;
+};
+
+export class SQLiteOAuthProvider implements OAuthServerProvider {
+	private _db: Database.Database | null = null;
+	private readonly dbPath: string;
+	private readonly issuerUrl: string;
+	private readonly pendingSessions = new Map<string, PendingSession>();
+
+	constructor(issuerUrl: string) {
+		this.issuerUrl = issuerUrl;
+		this.dbPath = process.env.OAUTH_DB_PATH ?? "./oauth.db";
+	}
+
+	private get db(): Database.Database {
+		if (!this._db) {
+			this._db = new Database(this.dbPath);
+			this._db.pragma("journal_mode = WAL");
+			this._db.exec(`
+				CREATE TABLE IF NOT EXISTS clients (
+					client_id TEXT PRIMARY KEY,
+					data_json TEXT NOT NULL
+				);
+				CREATE TABLE IF NOT EXISTS auth_codes (
+					code TEXT PRIMARY KEY,
+					client_id TEXT NOT NULL,
+					scopes TEXT NOT NULL,
+					expires_at REAL NOT NULL,
+					code_challenge TEXT NOT NULL,
+					redirect_uri TEXT NOT NULL,
+					resource TEXT
+				);
+				CREATE TABLE IF NOT EXISTS access_tokens (
+					token TEXT PRIMARY KEY,
+					client_id TEXT NOT NULL,
+					scopes TEXT NOT NULL,
+					expires_at INTEGER NOT NULL,
+					resource TEXT,
+					family_id TEXT NOT NULL
+				);
+				CREATE TABLE IF NOT EXISTS refresh_tokens (
+					token TEXT PRIMARY KEY,
+					client_id TEXT NOT NULL,
+					scopes TEXT NOT NULL,
+					expires_at INTEGER NOT NULL,
+					family_id TEXT NOT NULL
+				);
+			`);
+		}
+		return this._db;
+	}
+
+	get clientsStore(): OAuthRegisteredClientsStore {
+		return {
+			getClient: (clientId: string) => {
+				const row = this.db
+					.prepare("SELECT data_json FROM clients WHERE client_id = ?")
+					.get(clientId) as { data_json: string } | undefined;
+				if (!row) return undefined;
+				return JSON.parse(row.data_json) as OAuthClientInformationFull;
+			},
+			registerClient: (
+				client: Omit<
+					OAuthClientInformationFull,
+					"client_id" | "client_id_issued_at"
+				>,
+			) => {
+				const full: OAuthClientInformationFull = {
+					...client,
+					client_id: randomUUID(),
+					client_id_issued_at: Math.floor(Date.now() / 1000),
+				};
+				this.db
+					.prepare("INSERT INTO clients (client_id, data_json) VALUES (?, ?)")
+					.run(full.client_id, JSON.stringify(full));
+				return full;
+			},
+		};
+	}
+
+	async authorize(
+		client: OAuthClientInformationFull,
+		params: AuthorizationParams,
+		res: Response,
+	): Promise<void> {
+		const sessionId = randomBytes(16).toString("hex");
+		this.pendingSessions.set(sessionId, { client, params });
+		res.redirect(`${this.issuerUrl}/consent?session=${sessionId}`);
+	}
+
+	popPendingSession(id: string): PendingSession | undefined {
+		const session = this.pendingSessions.get(id);
+		this.pendingSessions.delete(id);
+		return session;
+	}
+
+	createAuthorizationCode(
+		clientId: string,
+		params: AuthorizationParams,
+	): string {
+		const code = randomBytes(32).toString("hex");
+		const expiresAt = Date.now() / 1000 + AUTH_CODE_TTL;
+		this.db
+			.prepare(
+				`INSERT INTO auth_codes
+				(code, client_id, scopes, expires_at, code_challenge, redirect_uri, resource)
+				VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.run(
+				code,
+				clientId,
+				JSON.stringify(params.scopes ?? []),
+				expiresAt,
+				params.codeChallenge,
+				params.redirectUri,
+				params.resource?.toString() ?? null,
+			);
+		return code;
+	}
+
+	async challengeForAuthorizationCode(
+		_client: OAuthClientInformationFull,
+		authorizationCode: string,
+	): Promise<string> {
+		const row = this.db
+			.prepare("SELECT code_challenge FROM auth_codes WHERE code = ?")
+			.get(authorizationCode) as { code_challenge: string } | undefined;
+		if (!row) throw new InvalidGrantError("Authorization code not found");
+		return row.code_challenge;
+	}
+
+	async exchangeAuthorizationCode(
+		client: OAuthClientInformationFull,
+		authorizationCode: string,
+		_codeVerifier?: string,
+		redirectUri?: string,
+		resource?: URL,
+	): Promise<OAuthTokens> {
+		const row = this.db
+			.prepare(
+				`SELECT client_id, scopes, expires_at, redirect_uri, resource
+				FROM auth_codes WHERE code = ?`,
+			)
+			.get(authorizationCode) as
+			| {
+					client_id: string;
+					scopes: string;
+					expires_at: number;
+					redirect_uri: string;
+					resource: string | null;
+			  }
+			| undefined;
+
+		if (!row) throw new InvalidGrantError("Authorization code not found");
+		if (row.expires_at < Date.now() / 1000)
+			throw new InvalidGrantError("Authorization code expired");
+		if (row.client_id !== client.client_id)
+			throw new InvalidGrantError("Client mismatch");
+
+		this.db
+			.prepare("DELETE FROM auth_codes WHERE code = ?")
+			.run(authorizationCode);
+
+		if (redirectUri && redirectUri !== row.redirect_uri)
+			throw new InvalidGrantError("Redirect URI mismatch");
+
+		const storedScopes: string[] = JSON.parse(row.scopes);
+		const familyId = randomUUID();
+		const accessTok = randomBytes(32).toString("hex");
+		const refreshTok = randomBytes(32).toString("hex");
+		const now = Math.floor(Date.now() / 1000);
+		const resourceStr = resource?.toString() ?? row.resource ?? null;
+
+		this.db
+			.prepare(
+				`INSERT INTO access_tokens (token, client_id, scopes, expires_at, resource, family_id)
+				VALUES (?, ?, ?, ?, ?, ?)`,
+			)
+			.run(
+				accessTok,
+				client.client_id,
+				JSON.stringify(storedScopes),
+				now + ACCESS_TOKEN_TTL,
+				resourceStr,
+				familyId,
+			);
+		this.db
+			.prepare(
+				`INSERT INTO refresh_tokens (token, client_id, scopes, expires_at, family_id)
+				VALUES (?, ?, ?, ?, ?)`,
+			)
+			.run(
+				refreshTok,
+				client.client_id,
+				JSON.stringify(storedScopes),
+				now + REFRESH_TOKEN_TTL,
+				familyId,
+			);
+
+		return {
+			access_token: accessTok,
+			token_type: "bearer",
+			expires_in: ACCESS_TOKEN_TTL,
+			scope: storedScopes.join(" "),
+			refresh_token: refreshTok,
+		};
+	}
+
+	async exchangeRefreshToken(
+		client: OAuthClientInformationFull,
+		refreshToken: string,
+		scopes?: string[],
+		_resource?: URL,
+	): Promise<OAuthTokens> {
+		const row = this.db
+			.prepare(
+				`SELECT client_id, scopes, expires_at, family_id
+				FROM refresh_tokens WHERE token = ?`,
+			)
+			.get(refreshToken) as
+			| {
+					client_id: string;
+					scopes: string;
+					expires_at: number;
+					family_id: string;
+			  }
+			| undefined;
+
+		if (!row) throw new InvalidGrantError("Refresh token not found");
+		if (row.expires_at < Math.floor(Date.now() / 1000))
+			throw new InvalidGrantError("Refresh token expired");
+		if (row.client_id !== client.client_id)
+			throw new InvalidGrantError("Client mismatch");
+
+		const storedScopes: string[] = JSON.parse(row.scopes);
+		if (scopes?.length) {
+			const invalid = scopes.filter((s) => !storedScopes.includes(s));
+			if (invalid.length)
+				throw new InvalidScopeError(
+					`Requested scopes exceed granted scopes: ${invalid.join(", ")}`,
+				);
+		}
+
+		const effectiveScopes = scopes?.length ? scopes : storedScopes;
+		const now = Math.floor(Date.now() / 1000);
+		const newFamilyId = row.family_id; // same family
+		const accessTok = randomBytes(32).toString("hex");
+		const refreshTok = randomBytes(32).toString("hex");
+
+		const rotate = this.db.transaction(() => {
+			this.db
+				.prepare("DELETE FROM refresh_tokens WHERE token = ?")
+				.run(refreshToken);
+			this.db
+				.prepare(
+					`INSERT INTO access_tokens (token, client_id, scopes, expires_at, resource, family_id)
+					VALUES (?, ?, ?, ?, ?, ?)`,
+				)
+				.run(
+					accessTok,
+					client.client_id,
+					JSON.stringify(effectiveScopes),
+					now + ACCESS_TOKEN_TTL,
+					null,
+					newFamilyId,
+				);
+			this.db
+				.prepare(
+					`INSERT INTO refresh_tokens (token, client_id, scopes, expires_at, family_id)
+					VALUES (?, ?, ?, ?, ?)`,
+				)
+				.run(
+					refreshTok,
+					client.client_id,
+					JSON.stringify(effectiveScopes),
+					now + REFRESH_TOKEN_TTL,
+					newFamilyId,
+				);
+		});
+		rotate();
+
+		return {
+			access_token: accessTok,
+			token_type: "bearer",
+			expires_in: ACCESS_TOKEN_TTL,
+			scope: effectiveScopes.join(" "),
+			refresh_token: refreshTok,
+		};
+	}
+
+	async verifyAccessToken(token: string): Promise<AuthInfo> {
+		const row = this.db
+			.prepare(
+				`SELECT client_id, scopes, expires_at, resource
+				FROM access_tokens WHERE token = ?`,
+			)
+			.get(token) as
+			| {
+					client_id: string;
+					scopes: string;
+					expires_at: number;
+					resource: string | null;
+			  }
+			| undefined;
+
+		if (!row) throw new InvalidTokenError("Access token not found");
+		if (row.expires_at < Math.floor(Date.now() / 1000))
+			throw new InvalidTokenError("Access token expired");
+
+		const scopes: string[] = JSON.parse(row.scopes);
+		return {
+			token,
+			clientId: row.client_id,
+			scopes,
+			expiresAt: row.expires_at,
+		};
+	}
+
+	async revokeToken(
+		_client: OAuthClientInformationFull,
+		request: OAuthTokenRevocationRequest,
+	): Promise<void> {
+		const token = request.token;
+
+		// Check access_tokens first, then refresh_tokens
+		const atRow = this.db
+			.prepare("SELECT family_id FROM access_tokens WHERE token = ?")
+			.get(token) as { family_id: string } | undefined;
+		const rtRow = !atRow
+			? (this.db
+					.prepare("SELECT family_id FROM refresh_tokens WHERE token = ?")
+					.get(token) as { family_id: string } | undefined)
+			: undefined;
+
+		const familyId = (atRow ?? rtRow)?.family_id;
+		if (!familyId) return; // no-op
+
+		this.db
+			.prepare("DELETE FROM access_tokens WHERE family_id = ?")
+			.run(familyId);
+		this.db
+			.prepare("DELETE FROM refresh_tokens WHERE family_id = ?")
+			.run(familyId);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--transport=http+oauth` mode that exposes a password-gated OAuth 2.1 authorization server + MCP resource server, compatible with claude.ai Connectors
- `SQLiteOAuthProvider` implements the MCP SDK's `OAuthServerProvider` interface backed by `better-sqlite3` (WAL mode, token family revocation, PKCE, refresh token rotation)
- Consent router with timing-safe password comparison (`MCP_AUTH_PASSWORD`)
- `startOAuthHttpServer()` wires `mcpAuthRouter` + `requireBearerAuth` from the MCP SDK
- `Dockerfile.oauth` + `docker-compose.yml` for local deployment (port 8012); the deprecated `Dockerfile` stub and `docker.test.ts` are untouched

## New environment variables (http+oauth mode)

| Variable | Description |
|---|---|
| `MCP_ISSUER_URL` | Public base URL of the server (also `--issuer-url=URL`) |
| `MCP_AUTH_PASSWORD` | Password for the consent form |
| `OAUTH_DB_PATH` | SQLite DB path (default: `./oauth.db`) |

## Test plan

- [ ] `npx vitest run --exclude 'tests/integration/**'` — all 189 unit tests pass
- [ ] `npx tsc --noEmit` — no type errors
- [ ] Manual smoke: `MCP_ISSUER_URL=http://localhost:3000 MCP_AUTH_PASSWORD=test HEVY_API_KEY=xxx node dist/cli.mjs --transport=http+oauth --port=3000`
- [ ] `curl http://localhost:3000/.well-known/oauth-authorization-server | jq .` returns OAuth metadata
- [ ] Unauthenticated `POST /mcp` returns 401 with `WWW-Authenticate: Bearer`
- [ ] `docker compose -f docker-compose.yml build && docker compose -f docker-compose.yml up -d`