### PR TITLE
fix(routines): omit null rep_range and unwrap mutation response

### DIFF
--- a/src/tools/routines.test.ts
+++ b/src/tools/routines.test.ts
@@ -151,7 +151,6 @@ describe("registerRoutineTools", () => {
 								distance_meters: null,
 								duration_seconds: null,
 								custom_metric: null,
-								rep_range: null,
 							},
 						],
 					},
@@ -444,6 +443,137 @@ describe("registerRoutineTools", () => {
 		expect(response.content[1]?.text).toContain("issues/261");
 	});
 
+	it("create-routine omits rep_range from reps-only sets", async () => {
+		// Regression test: the Hevy API rejects PUT payloads containing
+		// `rep_range: null` with "rep_range must be of type object", and the
+		// mobile app stores a null range object instead of treating the set
+		// as reps-only. When no rep range is provided, the field must be
+		// omitted from the outgoing payload.
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "created-routine",
+			title: "Reps Only",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:00:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			createRoutine: vi.fn().mockResolvedValue(routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "create-routine");
+
+		await handler({
+			title: "Reps Only",
+			folderId: null,
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [{ type: "normal", weightKg: 50, reps: 10 }],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const call = vi.mocked(hevyClient.createRoutine).mock.calls[0]?.[0] as {
+			routine: { exercises: Array<{ sets: Array<Record<string, unknown>> }> };
+		};
+		const set = call.routine.exercises[0]?.sets[0] as Record<string, unknown>;
+		expect(set).not.toHaveProperty("rep_range");
+		expect(set.reps).toBe(10);
+	});
+
+	it("update-routine omits rep_range from reps-only sets", async () => {
+		// Regression test: `update-routine` previously always sent
+		// `rep_range: repRange`, producing `rep_range: null` for reps-only
+		// sets. The Hevy API rejects that payload ("rep_range must be of
+		// type object"), so every update with at least one reps-only set
+		// failed. The field must be omitted when no range exists.
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "updated-routine",
+			title: "Reps Only",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:30:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			updateRoutine: vi.fn().mockResolvedValue(routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "update-routine");
+
+		await handler({
+			routineId: "routine-123",
+			title: "Reps Only",
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [
+						{ type: "warmup", weightKg: 40, reps: 6 },
+						{ type: "normal", weightKg: 60, reps: 10 },
+					],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const call = vi.mocked(hevyClient.updateRoutine).mock.calls[0]?.[1] as {
+			routine: { exercises: Array<{ sets: Array<Record<string, unknown>> }> };
+		};
+		const sets = call.routine.exercises[0]?.sets ?? [];
+		for (const set of sets) {
+			expect(set).not.toHaveProperty("rep_range");
+		}
+	});
+
+	it("update-routine preserves rep_range when a real range is provided", async () => {
+		// Counterpart to the omit regression: when the caller supplies a
+		// real rep range, it must round-trip into the payload as an object
+		// so the Hevy API stores it.
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "updated-routine",
+			title: "With Range",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:30:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			updateRoutine: vi.fn().mockResolvedValue(routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "update-routine");
+
+		await handler({
+			routineId: "routine-123",
+			title: "With Range",
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [
+						{
+							type: "normal",
+							weightKg: 80,
+							reps: null,
+							repRange: { start: 8, end: 12 },
+						},
+					],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const call = vi.mocked(hevyClient.updateRoutine).mock.calls[0]?.[1] as {
+			routine: { exercises: Array<{ sets: Array<Record<string, unknown>> }> };
+		};
+		const set = call.routine.exercises[0]?.sets[0] as Record<string, unknown>;
+		expect(set.rep_range).toEqual({ start: 8, end: 12 });
+	});
+
 	it("create-routine schema keeps reps null (does not coerce to 0)", () => {
 		const { server, tool } = createMockServer();
 		registerRoutineTools(server, null);
@@ -685,7 +815,6 @@ describe("registerRoutineTools", () => {
 								distance_meters: null,
 								duration_seconds: null,
 								custom_metric: null,
-								rep_range: null,
 							},
 						],
 					},

--- a/src/tools/routines.test.ts
+++ b/src/tools/routines.test.ts
@@ -443,6 +443,81 @@ describe("registerRoutineTools", () => {
 		expect(response.content[1]?.text).toContain("issues/261");
 	});
 
+	it("create-routine unwraps {routine: [...]} mutation response", async () => {
+		// Regression test: the Hevy API returns POST /v1/routines as
+		// `{ routine: [Routine] }` (a one-element array nested under a
+		// `routine` key), but the generated OpenAPI types claim the response
+		// IS a Routine. The handler must defensively unwrap so the tool
+		// returns the actual routine object, not "{}".
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "created-routine",
+			title: "Wrapped Response",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:00:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			createRoutine: vi
+				.fn()
+				.mockResolvedValue({ routine: [routine] } as unknown as Routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "create-routine");
+
+		const response = await handler({
+			title: "Wrapped Response",
+			folderId: null,
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [{ type: "normal", weightKg: 50, reps: 10 }],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const parsed = JSON.parse(response.content[0].text) as unknown;
+		expect(parsed).toEqual(formatRoutine(routine));
+	});
+
+	it("update-routine unwraps {routine: [...]} mutation response", async () => {
+		// Regression test: PUT /v1/routines/:id has the same wrapping
+		// behaviour as POST; unwrap so the response isn't "{}".
+		const { server, tool } = createMockServer();
+		const routine: Routine = {
+			id: "updated-routine",
+			title: "Wrapped Response",
+			folder_id: null,
+			created_at: "2025-03-26T19:00:00Z",
+			updated_at: "2025-03-26T19:30:00Z",
+			exercises: [],
+		};
+		const hevyClient: HevyClient = {
+			updateRoutine: vi
+				.fn()
+				.mockResolvedValue({ routine: [routine] } as unknown as Routine),
+		} as unknown as HevyClient;
+
+		registerRoutineTools(server, hevyClient);
+		const { handler } = getToolRegistration(tool, "update-routine");
+
+		const response = await handler({
+			routineId: "routine-123",
+			title: "Wrapped Response",
+			exercises: [
+				{
+					exerciseTemplateId: "template-id",
+					sets: [{ type: "normal", weightKg: 50, reps: 10 }],
+				},
+			],
+		} as Record<string, unknown>);
+
+		const parsed = JSON.parse(response.content[0].text) as unknown;
+		expect(parsed).toEqual(formatRoutine(routine));
+	});
+
 	it("create-routine omits rep_range from reps-only sets", async () => {
 		// Regression test: the Hevy API rejects PUT payloads containing
 		// `rep_range: null` with "rep_range must be of type object", and the

--- a/src/tools/routines.ts
+++ b/src/tools/routines.ts
@@ -119,6 +119,31 @@ function getFixedRepsFromRepRange(
 	return start;
 }
 
+/**
+ * Unwraps the mutation (POST/PUT) response from the Hevy API.
+ *
+ * The API wraps the created/updated routine in `{ routine: [routineObj] }`
+ * — a single-element array inside a `routine` key — even though the
+ * generated OpenAPI types claim the response body IS a Routine. Until the
+ * spec is corrected, unwrap defensively: accept either the wrapped shape,
+ * `{ routine: routineObj }`, or a bare Routine, so callers always receive
+ * a single Routine (or null).
+ */
+function unwrapMutationResponse(data: unknown): Routine | null {
+	if (!data || typeof data !== "object") {
+		return null;
+	}
+	const maybeWrapped = data as { routine?: Routine | Routine[] };
+	if (maybeWrapped.routine !== undefined) {
+		const r = maybeWrapped.routine;
+		if (Array.isArray(r)) {
+			return r[0] ?? null;
+		}
+		return r;
+	}
+	return data as Routine;
+}
+
 const repRangeDisplayWarningText =
 	"Note: Hevy's public API stores rep ranges (rep_range), but the Hevy apps may " +
 	"not display them because they rely on an internal-only exercise field " +
@@ -291,13 +316,18 @@ export function registerRoutineTools(
 				},
 			});
 
-			if (!data) {
+			// The Hevy API returns { routine: [Routine] } on POST — a wrapper
+			// around an array with a single element — even though the
+			// generated OpenAPI type claims the response IS a Routine. Unwrap
+			// it so `formatRoutine` receives the actual routine object.
+			const created = unwrapMutationResponse(data);
+			if (!created) {
 				return createEmptyResponse(
 					"Failed to create routine: Server returned no data",
 				);
 			}
 
-			const routine = formatRoutine(data);
+			const routine = formatRoutine(created);
 			const response = createJsonResponse(routine, {
 				pretty: true,
 				indent: 2,
@@ -410,13 +440,15 @@ export function registerRoutineTools(
 				},
 			);
 
-			if (!data) {
+			// The Hevy API returns { routine: [Routine] } on PUT as well.
+			const updated = unwrapMutationResponse(data);
+			if (!updated) {
 				return createEmptyResponse(
 					`Failed to update routine with ID ${routineId}`,
 				);
 			}
 
-			const routine = formatRoutine(data);
+			const routine = formatRoutine(updated);
 			const response = createJsonResponse(routine, {
 				pretty: true,
 				indent: 2,

--- a/src/tools/routines.ts
+++ b/src/tools/routines.ts
@@ -261,7 +261,12 @@ export function registerRoutineTools(
 								distance_meters: set.distance ?? set.distanceMeters ?? null,
 								duration_seconds: set.duration ?? set.durationSeconds ?? null,
 								custom_metric: set.customMetric ?? null,
-								rep_range: repRange,
+								// Omit rep_range when null. The Hevy API rejects PUT
+								// payloads with `rep_range: null` ("rep_range must be of
+								// type object"), and on POST we prefer omitting so the
+								// app treats the set as reps-only rather than storing a
+								// null range object.
+								...(repRange !== null && { rep_range: repRange }),
 							};
 						});
 
@@ -375,7 +380,11 @@ export function registerRoutineTools(
 									distance_meters: set.distance ?? set.distanceMeters ?? null,
 									duration_seconds: set.duration ?? set.durationSeconds ?? null,
 									custom_metric: set.customMetric ?? null,
-									rep_range: repRange,
+									// Omit rep_range when null. The Hevy API rejects PUT
+									// payloads with `rep_range: null` ("rep_range must be
+									// of type object"), which breaks every reps-only set
+									// (warmups and sets without a prescribed range).
+									...(repRange !== null && { rep_range: repRange }),
 								};
 							});
 


### PR DESCRIPTION
Cherry-picks the fixes from upstream PR [chrisdoc/hevy-mcp#301](https://github.com/chrisdoc/hevy-mcp/pull/301) by @jirik-s.

## Summary

Two bugs in \`create-routine\` / \`update-routine\` that surface against the live Hevy API:

1. **\`update-routine\` rejects every routine with a reps-only set.** The handlers always spread \`rep_range: repRange\` into the outgoing payload; when the caller omits \`repRange\`, \`buildRepRange()\` returns \`null\`, and the API rejects \`rep_range: null\` with \`"rep_range must be of type object"\`. Fix: conditional spread so the field is omitted entirely when no range exists.
2. **\`create-routine\` and \`update-routine\` return \`{}\` instead of the routine.** The Hevy API returns \`{ routine: [Routine] }\` (single-element array under a \`routine\` key), but the generated OpenAPI types claim the response **is** a \`Routine\`. \`formatRoutine\` reads undefined fields off the wrapper, and \`JSON.stringify\` drops them, yielding \`{}\`. Fix: a small \`unwrapMutationResponse\` helper that accepts the wrapped-array, wrapped-object, or bare shapes — same pattern \`get-routine\` already uses.

## Verification

- \`npm run check:types\` — clean
- \`npm run check\` (oxlint + oxfmt) — clean
- \`npx vitest run src\` — 151/151 tests pass, including 5 new regression tests:
  - \`create-routine\` / \`update-routine\` omit \`rep_range\` from reps-only sets
  - \`update-routine\` preserves \`rep_range\` when a real range is provided
  - \`create-routine\` / \`update-routine\` unwrap \`{routine: [...]}\` mutation response

## Test plan

- [ ] Smoke-test against a live Hevy account: create a routine with a reps-only set, confirm response contains the new id (not \`{}\`)
- [ ] Update a routine with a mix of warmup (reps-only), working set with rep range, and reps-only working set — confirm round-trip